### PR TITLE
Close #1135: Using JS resizeTo directly on renderer (#1136)

### DIFF
--- a/__mocks__/jquery.mjs
+++ b/__mocks__/jquery.mjs
@@ -17,3 +17,6 @@ window.matchMedia = window.matchMedia || function()
 
 // Mocking requestAnimationFrame since it's not usually defined but we use it
 global.requestAnimationFrame = callback => callback();
+
+// Mocking resizeTo since it's not implemented by JSDOM but used by the calendar
+window.resizeTo = () => {};

--- a/__tests__/__main__/user-preferences.mjs
+++ b/__tests__/__main__/user-preferences.mjs
@@ -55,24 +55,16 @@ describe('Preferences Main', () =>
     {
         it('Month view', function()
         {
-            // For some reason this test takes longer when running the whole testsuite. My suspicion is that
-            // writing to file inside getDefaultWidthHeight is taking longer after many tests write to the file.
-            // Thus, increasing the timeout.
-            this.timeout(15000);
-            assert.strictEqual(getDefaultPreferences()['view'], 'month');
-            savePreferences(getDefaultPreferences());
-
-            assert.deepStrictEqual(getDefaultWidthHeight(), { width: 1010, height: 800 });
+            const preferences = structuredClone(getDefaultPreferences());
+            assert.strictEqual(preferences['view'], 'month');
+            assert.deepStrictEqual(getDefaultWidthHeight(preferences), { width: 1010, height: 800 });
         });
 
         it('Day view', () =>
         {
             const preferences = structuredClone(getDefaultPreferences());
-
             preferences['view'] = 'day';
-            savePreferences(preferences);
-
-            assert.deepStrictEqual(getDefaultWidthHeight(), { width: 500, height: 500 });
+            assert.deepStrictEqual(getDefaultWidthHeight(preferences), { width: 500, height: 500 });
         });
     });
 

--- a/__tests__/__main__/windows.mjs
+++ b/__tests__/__main__/windows.mjs
@@ -45,6 +45,8 @@ describe('Windows tests', () =>
         {
             return new Promise(resolve => resolve([]));
         });
+
+        Windows.resetWindowsElements();
     });
 
     it('Elements should be null on starting', () =>

--- a/__tests__/__renderer__/classes/CalendarFactory.mjs
+++ b/__tests__/__renderer__/classes/CalendarFactory.mjs
@@ -20,7 +20,7 @@ describe('CalendarFactory', () =>
         // Mocked APIs from the preload script of the calendar window
         window.calendarApi = calendarApi;
 
-        window.calendarApi.resizeMainWindow = stub();
+        stub(CalendarFactory, 'ResizeCalendar');
 
         Object.setPrototypeOf(DayCalendar, stub());
         Object.setPrototypeOf(MonthCalendar, stub());
@@ -61,7 +61,7 @@ describe('CalendarFactory', () =>
 
         it('Should return new calendar with resizing if passing in an instance that is not a DayCalendar', async() =>
         {
-            window.calendarApi.resizeMainWindow.resetHistory();
+            CalendarFactory.ResizeCalendar.resetHistory();
             let calls = 0;
             const testCalendar = {
                 constructor: {
@@ -76,17 +76,17 @@ describe('CalendarFactory', () =>
             }, {}, testCalendar);
             assert.strictEqual(calendar instanceof DayCalendar, true);
             assert.strictEqual(calls, 0);
-            assert.strictEqual(window.calendarApi.resizeMainWindow.calledOnce, true);
+            assert.strictEqual(CalendarFactory.ResizeCalendar.calledOnce, true);
         });
 
         it('Should return new calendar without resizing if passing in an undefined instance', async() =>
         {
-            window.calendarApi.resizeMainWindow.resetHistory();
+            CalendarFactory.ResizeCalendar.resetHistory();
             const calendar = await CalendarFactory.getInstance({
                 view: 'day',
             }, {}, undefined);
             assert.strictEqual(calendar instanceof DayCalendar, true);
-            assert.strictEqual(window.calendarApi.resizeMainWindow.notCalled, true);
+            assert.strictEqual(CalendarFactory.ResizeCalendar.notCalled, true);
         });
     });
 
@@ -112,17 +112,17 @@ describe('CalendarFactory', () =>
 
         it('Should return new calendar without resizing if passing in an undefined instance', async() =>
         {
-            window.calendarApi.resizeMainWindow.resetHistory();
+            CalendarFactory.ResizeCalendar.resetHistory();
             const calendar = await CalendarFactory.getInstance({
                 view: 'month',
             }, {}, undefined);
             assert.strictEqual(calendar instanceof MonthCalendar, true);
-            assert.strictEqual(window.calendarApi.resizeMainWindow.notCalled, true);
+            assert.strictEqual(CalendarFactory.ResizeCalendar.notCalled, true);
         });
 
         it('Should return new calendar with resizing if passing in an instance that is not a MonthCalendar', async() =>
         {
-            window.calendarApi.resizeMainWindow.resetHistory();
+            CalendarFactory.ResizeCalendar.resetHistory();
             let calls = 0;
             const testCalendar = {
                 constructor: {
@@ -137,7 +137,7 @@ describe('CalendarFactory', () =>
             }, {}, testCalendar);
             assert.strictEqual(calendar instanceof MonthCalendar, true);
             assert.strictEqual(calls, 0);
-            assert.strictEqual(window.calendarApi.resizeMainWindow.calledOnce, true);
+            assert.strictEqual(CalendarFactory.ResizeCalendar.calledOnce, true);
         });
     });
 
@@ -146,5 +146,6 @@ describe('CalendarFactory', () =>
         Object.setPrototypeOf(DayCalendar, DayCalendarPrototype);
         Object.setPrototypeOf(MonthCalendar, MonthCalendarPrototype);
         BaseCalendar.prototype.reload.restore();
+        CalendarFactory.ResizeCalendar.restore();
     });
 });

--- a/__tests__/__renderer__/classes/DayCalendar.mjs
+++ b/__tests__/__renderer__/classes/DayCalendar.mjs
@@ -51,7 +51,6 @@ describe('DayCalendar class Tests', () =>
 
         // Stubbing methods that don't need the actual implementation for the tests
         window.calendarApi.toggleTrayPunchTime = () => {};
-        window.calendarApi.resizeMainWindow = () => {};
         BaseCalendar.prototype._getTranslation = () => {};
         BaseCalendar.prototype.redraw = () => {};
 

--- a/__tests__/__renderer__/classes/MonthCalendar.mjs
+++ b/__tests__/__renderer__/classes/MonthCalendar.mjs
@@ -51,7 +51,6 @@ describe('MonthCalendar class Tests', () =>
 
         // Stubbing methods that don't need the actual implementation for the tests
         // window.calendarApi.toggleTrayPunchTime = () => {};
-        window.calendarApi.resizeMainWindow = () => {};
         BaseCalendar.prototype._getTranslation = () => {};
         BaseCalendar.prototype.redraw = () => {};
         window.calendarApi.getStoreContents = () => { return new Promise((resolve) => { resolve(entryStore.store); }); };

--- a/js/ipc-constants.mjs
+++ b/js/ipc-constants.mjs
@@ -23,7 +23,6 @@ const IpcConstants = Object.freeze(
         RefreshOnDayChange: 'REFRESH_ON_DAY_CHANGE',
         ReloadCalendar: 'RELOAD_CALENDAR',
         ReloadTheme: 'RELOAD_THEME',
-        ResizeMainWindow: 'RESIZE_MAIN_WINDOW',
         SetStoreData: 'SET_STORE_DATA',
         SetWaiver: 'SET_WAIVER',
         SetWaiverDay: 'SET_WAIVER_DAY',

--- a/js/main-window.mjs
+++ b/js/main-window.mjs
@@ -70,8 +70,8 @@ function createMenu()
 function createWindow()
 {
     // Create the browser window.
-    const widthHeight = getDefaultWidthHeight();
     const userPreferences = getUserPreferences();
+    const widthHeight = getDefaultWidthHeight(userPreferences);
     mainWindow = new BrowserWindow({
         width: widthHeight.width,
         height: widthHeight.height,
@@ -102,12 +102,6 @@ function createWindow()
         contextMenuTemplate[0].enabled = arg;
         global.contextMenu = Menu.buildFromTemplate(contextMenuTemplate);
         global.tray.setContextMenu(global.contextMenu);
-    });
-
-    ipcMain.on(IpcConstants.ResizeMainWindow, () =>
-    {
-        const widthHeight = getDefaultWidthHeight();
-        mainWindow.setSize(widthHeight.width, widthHeight.height);
     });
 
     ipcMain.on(IpcConstants.SwitchView, () =>

--- a/js/user-preferences.mjs
+++ b/js/user-preferences.mjs
@@ -285,9 +285,8 @@ function switchCalendarView()
     return preferences;
 }
 
-function getDefaultWidthHeight()
+function getDefaultWidthHeight(preferences)
 {
-    const preferences = getLoadedOrDerivedUserPreferences();
     if (preferences['view'] === 'month')
     {
         return { width: 1010, height: 800 };
@@ -297,7 +296,6 @@ function getDefaultWidthHeight()
         return { width: 500, height: 500 };
     }
 }
-
 
 /*
  * Returns the value of language in preferences.

--- a/renderer/classes/CalendarFactory.js
+++ b/renderer/classes/CalendarFactory.js
@@ -19,7 +19,7 @@ class CalendarFactory
         {
             if (calendar !== undefined && calendar.constructor.name !== constructorName)
             {
-                window.calendarApi.resizeMainWindow();
+                CalendarFactory.ResizeCalendar(preferences);
             }
             calendar = new CalendarClass(preferences, languageData);
             await calendar.reload();
@@ -32,6 +32,12 @@ class CalendarFactory
             calendar.redraw();
             return calendar;
         }
+    }
+
+    static ResizeCalendar(preferences)
+    {
+        const widthHeight = window.calendarApi.getDefaultWidthHeight(preferences);
+        window.resizeTo(widthHeight.width, widthHeight.height);
     }
 }
 

--- a/renderer/preload-scripts/calendar-api.mjs
+++ b/renderer/preload-scripts/calendar-api.mjs
@@ -2,14 +2,10 @@
 
 import { createRequire } from 'module';
 import IpcConstants from '../../js/ipc-constants.mjs';
+import { getDefaultWidthHeight } from '../../js/user-preferences.mjs';
 const require = createRequire(import.meta.url);
 
 const { ipcRenderer } = require('electron');
-
-function resizeMainWindow()
-{
-    ipcRenderer.send(IpcConstants.ResizeMainWindow);
-}
 
 function switchView()
 {
@@ -54,7 +50,7 @@ const calendarApi = {
     handlePunchDate: (callback) => ipcRenderer.on(IpcConstants.PunchDate, callback),
     handleThemeChange: (callback) => ipcRenderer.on(IpcConstants.ReloadTheme, callback),
     handleLeaveBy: (callback) => ipcRenderer.on(IpcConstants.GetLeaveBy, callback),
-    resizeMainWindow: () => resizeMainWindow(),
+    getDefaultWidthHeight: getDefaultWidthHeight,
     switchView: () => switchView(),
     toggleTrayPunchTime: (enable) => toggleTrayPunchTime(enable),
     displayWaiverWindow: (waiverDay) => displayWaiverWindow(waiverDay),


### PR DESCRIPTION
* Using JS resizeTo directly on renderer

* Adding tests

* Ensuring windows.mjs tests start fresh

* Improving test

* Making test more adaptable to macos run

* Restoring setTimeout

* Checking possible heights

#### Related issue
Closes #<!--Related issue-->

#### Context / Background
<!--
- Briefly explain the purpose of the PR by providing a summary of the context
-->

#### What change is being introduced by this PR?
<!--
- How did you approach this problem?
- What changes did you make to achieve the goal?
- What are the indirect and direct consequences of the change?
-->

#### How will this be tested?
<!--
- How will you verify whether your changes worked as expected once merged?
-->

----
<!--
- If this PR is for translation, please mark the box below
-->
- [ ] I confirm I'm a native or fluent speaker of the language I'm translating to.
