### PR TITLE
await window.waitForLoadState('domcontentloaded') to speed tests

### DIFF
--- a/tests/main-window.mjs
+++ b/tests/main-window.mjs
@@ -44,6 +44,7 @@ describe('Application launch', function()
     {
         // TODO: Investigate why this takes such a long time (10s)
         const window = await electronApp.firstWindow();
+        await window.waitForLoadState('domcontentloaded');
 
         const monthYearLocator = window.locator('#month-year');
         const monthYearText = await monthYearLocator.evaluate(node => node.innerText);


### PR DESCRIPTION
I'm not actually sure of why this works.